### PR TITLE
Update REAMDE links to point to github.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ bioutils -- simple bioinformatics utilities and lookup tables
 |ci_badge| | |pypi_badge| | |issues_badge|
 
 bioutils provides some common tools and lookup tables used primarly by
-the `hgvs <https://bitbucket.org/biocommons/hgvs/>`_ and `uta
-<https://bitbucket.org/biocommons/uta/>`_ packages.  This package is
+the `hgvs <https://github.com/biocommons/hgvs/>`_ and `uta
+<https://github.com/biocommons/uta/>`_ packages.  This package is
 not really intended for broader use (read: it may change without
 notice).
 


### PR DESCRIPTION
I noticed the links in this repository still link to BitBucket, but the referenced repositories have transitioned to Github.