### PR TITLE
logging http error if detected

### DIFF
--- a/bioutils/seqfetcher.py
+++ b/bioutils/seqfetcher.py
@@ -117,7 +117,8 @@ def fetch_seq(ac, start_i=None, end_i=None):
 
     try:
         return fetcher(ac, start_i, end_i)
-    except requests.HTTPError:
+    except requests.HTTPError as ex:
+        logger.error(ex)
         raise RuntimeError("No sequence available for {ac}".format(ac=ac))
 
 


### PR DESCRIPTION
i spent an embarrassing amount of time trying to track down why a request was failing, and was only seeing "No sequence available ... " which was misleading because sometimes it worked and sometimes it didn't. including this error message could potentially save somebody else the time i wasted troubleshooting. it turned out my error was an HTTP 429 Too Many Requests because i wasn't using a dedicated API key, but the existing error message was misleading in that it seemed it was telling me the sequence i was using wasn't available (when i knew it was)