### PR TITLE
fix: don't retry on invalid input with ncbi

### DIFF
--- a/src/bioutils/seqfetcher.py
+++ b/src/bioutils/seqfetcher.py
@@ -218,6 +218,10 @@ def _fetch_seq_ncbi(ac, start_i=None, end_i=None):
         if resp.ok:
             seq = "".join(resp.text.splitlines()[1:])
             return seq
+        elif resp.status_code == 400:
+            # Invalid sequence or start/stop position for that sequence
+            raise Exception("Fetching sequence {} with start index {} and end index {} failed, invalid sequence "
+                            "or start or end position".format(ac, start_i, end_i))
         if n_retries >= retry_limit:
             break
         if n_retries == 0:

--- a/src/bioutils/seqfetcher.py
+++ b/src/bioutils/seqfetcher.py
@@ -218,11 +218,7 @@ def _fetch_seq_ncbi(ac, start_i=None, end_i=None):
         if resp.ok:
             seq = "".join(resp.text.splitlines()[1:])
             return seq
-        elif resp.status_code == 400:
-            # Invalid sequence or start/stop position for that sequence
-            raise Exception("Fetching sequence {} with start index {} and end index {} failed, invalid sequence "
-                            "or start or end position".format(ac, start_i, end_i))
-        if n_retries >= retry_limit:
+        if resp.status_code == 400 or n_retries >= retry_limit:
             break
         if n_retries == 0:
             _logger.warning("Failed to fetch {}".format(url))

--- a/src/bioutils/seqfetcher.py
+++ b/src/bioutils/seqfetcher.py
@@ -15,7 +15,6 @@ import requests
 
 _logger = logging.getLogger(__name__)
 
-
 # Reece requested registration on 2017-09-03
 ncbi_tool = "bioutils"
 ncbi_email = "biocommons-dev@googlegroups.com"
@@ -218,7 +217,11 @@ def _fetch_seq_ncbi(ac, start_i=None, end_i=None):
         if resp.ok:
             seq = "".join(resp.text.splitlines()[1:])
             return seq
-        if resp.status_code == 400 or n_retries >= retry_limit:
+        elif resp.status_code == 400:
+            # Invalid sequence or start/stop position for that sequence
+            raise RuntimeError("Fetching sequence {} with start index {} and end index {} failed, invalid sequence "
+                               "or start or end position".format(ac, start_i, end_i))
+        if n_retries >= retry_limit:
             break
         if n_retries == 0:
             _logger.warning("Failed to fetch {}".format(url))
@@ -245,7 +248,6 @@ def _add_eutils_api_key(url):
     if apikey:
         url += "&api_key={apikey}".format(apikey=apikey)
     return url
-
 
 
 # So that I don't forget why I didn't use ebi too:

--- a/tests/test_seqfetcher.py
+++ b/tests/test_seqfetcher.py
@@ -27,9 +27,8 @@ def test_fetch_seq():
 
 @vcr.use_cassette
 def test_fetch_seq_ncbi_invalid_positions():
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(RuntimeError):
         _fetch_seq_ncbi("NP_001230161.1", "3190", "3190")
-    assert "invalid sequence or start or end position" in str(excinfo.value)
 
 @vcr.use_cassette
 def test_add_eutils_api_key():

--- a/tests/test_seqfetcher.py
+++ b/tests/test_seqfetcher.py
@@ -28,7 +28,7 @@ def test_fetch_seq():
 @vcr.use_cassette
 def test_fetch_seq_ncbi_invalid_positions():
     with pytest.raises(RuntimeError):
-        _fetch_seq_ncbi("NP_001230161.1", "3190", "3190")
+        _fetch_seq_ncbi("NP_001230161.1", 3190, 3190)
 
 @vcr.use_cassette
 def test_add_eutils_api_key():

--- a/tests/test_seqfetcher.py
+++ b/tests/test_seqfetcher.py
@@ -25,6 +25,11 @@ def test_fetch_seq():
     assert 'CGCCTCCCTTCCCCCTCCCCGCCCG' == fetch_seq('ENST00000288602', 0, 25)
     assert 'MAALSGGGGGGAEPGQALFNGDMEP' == fetch_seq('ENSP00000288602', 0, 25)
 
+@vcr.use_cassette
+def test_fetch_seq_ncbi_invalid_positions():
+    with pytest.raises(Exception) as excinfo:
+        _fetch_seq_ncbi("NP_001230161.1", "3190", "3190")
+    assert "invalid sequence or start or end position" in str(excinfo.value)
 
 @vcr.use_cassette
 def test_add_eutils_api_key():

--- a/tests/test_seqfetcher.py
+++ b/tests/test_seqfetcher.py
@@ -27,8 +27,9 @@ def test_fetch_seq():
 
 @vcr.use_cassette
 def test_fetch_seq_ncbi_invalid_positions():
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as excinfo:
         _fetch_seq_ncbi("NP_001230161.1", 3190, 3190)
+    assert "invalid sequence or start or end position" in str(excinfo.value)
 
 @vcr.use_cassette
 def test_add_eutils_api_key():


### PR DESCRIPTION
When the ncbi sequence endpoint is hit with invalid input, for example invalid start/end positions for a certain protein sequence it will return a http status code of 400 [as expected](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). The current biotools library keeps retrying, even tough the response of the server will not change, it's not a connection issue.

This fix let's the function fail immediately instead of retrying when it returns a status code 400.