### PR TITLE
Independent control of trimming and shuffling in `normalize()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .coverage.*
 .eggs/
 .env
+.idea
 .installed.cfg
 .ipynb_checkpoints
 .pytest_cache

--- a/src/bioutils/normalize.py
+++ b/src/bioutils/normalize.py
@@ -53,9 +53,10 @@ def normalize(
         bounds (2-tuple of int, optional): Maximal extent of normalization left and right.
             Must be provided if sequence doesn't support ``__len__``. Defaults to ``(0, len(sequence))``.
         mode (NormalizationMode Enum or string, optional): A NormalizationMode Enum or the corresponding string.
-            Defaults to ``EXPAND``.
+            Defaults to ``EXPAND``. Set to None to skip shuffling. Does not affect trimming or anchoring.
         anchor (int, optional): number of flanking residues left and right. Defaults to ``0``.
         trim (bool): indicates whether to trim the common prefix and suffix of alleles. Defaults to True.
+            Set to False to skip trimming. Does not affect shuffling or anchoring.
 
     Returns:
         tuple: ``(new_interval, [new_alleles])``

--- a/src/bioutils/normalize.py
+++ b/src/bioutils/normalize.py
@@ -106,8 +106,6 @@ def normalize(
         raise ValueError("First allele, the reference allele, must be None")
     alleles = list(alleles)  # in case tuple
     alleles[0] = sequence[interval.start : interval.end]
-    if len(set(alleles)) < 2:
-        raise ValueError("Must have at least two distinct alleles to normalize")
 
     if debug:
         _print_state(
@@ -119,6 +117,9 @@ def normalize(
         )
 
     if trim:
+        if len(set(alleles)) < 2:
+            raise ValueError("Must have at least two distinct alleles to trim")
+
         # Trim: remove common suffix, prefix, and adjust interval to match
         l_trimmed, alleles = trim_left(alleles)
         interval.start += l_trimmed

--- a/src/bioutils/normalize.py
+++ b/src/bioutils/normalize.py
@@ -7,6 +7,7 @@ import copy
 import enum
 import logging
 import math
+from typing import Optional
 
 import attr
 
@@ -22,7 +23,7 @@ Attributes:
     EXPAND: Normalize alleles to maximal extent both left and right.
     LEFTSHUFFLE: Normalize alleles to maximal extent left.
     RIGHTSHUFFLE: Normalize alleles to maximal extent right.
-    TRIMONLY: Only trim the common prefix and suffix of alleles.
+    TRIMONLY: Only trim the common prefix and suffix of alleles. Deprecated -- use `mode=None` with `trim=True` instead.
     VCF: Normalize with VCF. 
 """
 
@@ -31,7 +32,7 @@ def normalize(
     sequence,
     interval,
     alleles,
-    mode=NormalizationMode.EXPAND,
+    mode: Optional[NormalizationMode] = NormalizationMode.EXPAND,
     bounds=None,
     anchor_length=0,
     trim: bool = True,

--- a/src/bioutils/normalize.py
+++ b/src/bioutils/normalize.py
@@ -34,8 +34,14 @@ def normalize(
     mode=NormalizationMode.EXPAND,
     bounds=None,
     anchor_length=0,
+    trim: bool = True,
 ):
     """Normalizes the alleles that co-occur on sequence at interval, ensuring comparable representations.
+
+    Normalization performs three operations:
+    - trimming
+    - shuffling
+    - anchoring
 
     Args:
         sequence (str or iterable): The reference sequence; must support indexing and ``__getitem__``.
@@ -48,6 +54,7 @@ def normalize(
         mode (NormalizationMode Enum or string, optional): A NormalizationMode Enum or the corresponding string.
             Defaults to ``EXPAND``.
         anchor (int, optional): number of flanking residues left and right. Defaults to ``0``.
+        trim (bool): indicates whether to trim the common prefix and suffix of alleles. Defaults to True.
 
     Returns:
         tuple: ``(new_interval, [new_alleles])``
@@ -109,19 +116,20 @@ def normalize(
             comment="Starting state",
         )
 
-    # Trim: remove common suffix, prefix, and adjust interval to match
-    l_trimmed, alleles = trim_left(alleles)
-    interval.start += l_trimmed
-    r_trimmed, alleles = trim_right(alleles)
-    interval.end -= r_trimmed
-    if debug:
-        _print_state(
-            interval,
-            bounds,
-            sequence=sequence,
-            alleles=alleles,
-            comment="After trimming",
-        )
+    if trim:
+        # Trim: remove common suffix, prefix, and adjust interval to match
+        l_trimmed, alleles = trim_left(alleles)
+        interval.start += l_trimmed
+        r_trimmed, alleles = trim_right(alleles)
+        interval.end -= r_trimmed
+        if debug:
+            _print_state(
+                interval,
+                bounds,
+                sequence=sequence,
+                alleles=alleles,
+                comment="After trimming",
+            )
 
     lens = [len(a) for a in alleles]
 

--- a/src/bioutils/normalize.py
+++ b/src/bioutils/normalize.py
@@ -98,6 +98,8 @@ def normalize(
             raise ValueError(
                 "May not provide non-zero anchor size with VCF normalization mode"
             )
+        if not trim:
+            raise ValueError("May not disable trimming with VCF normalization mode")
         mode = NormalizationMode.LEFTSHUFFLE
         left_anchor = 1
         right_anchor = 0

--- a/src/bioutils/normalize.py
+++ b/src/bioutils/normalize.py
@@ -90,7 +90,7 @@ def normalize(
 
     left_anchor = right_anchor = anchor_length
 
-    if not isinstance(mode, NormalizationMode):
+    if mode is not None and not isinstance(mode, NormalizationMode):
         mode = NormalizationMode[mode]  # e.g., mode="LEFTSHUFFLE" OK
 
     if mode == NormalizationMode.VCF:
@@ -170,7 +170,7 @@ def normalize(
             bounds,
             sequence=sequence,
             alleles=alleles,
-            comment=f"After {mode}",
+            comment=f"After mode: {mode}",
         )
 
     # Add left and/or right flanking sequence

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -14,9 +14,9 @@ normalize_left = partial(normalize_seq, mode=NormalizationMode.LEFTSHUFFLE)
 normalize_right = partial(normalize_seq, mode=NormalizationMode.RIGHTSHUFFLE)
 normalize_expand = partial(normalize_seq, mode=NormalizationMode.EXPAND)
 normalize_vcf = partial(normalize_seq, mode=NormalizationMode.VCF)
-# normalize_left_no_trim = partial(normalize_seq, mode=None, trim=True)
-# normalize_right_no_trim = partial(normalize_seq, mode=None, trim=True)
-# normalize_expand_no_trim = partial(normalize_seq, mode=None, trim=True)
+normalize_left_no_trim = partial(normalize_seq, mode=NormalizationMode.LEFTSHUFFLE, trim=False)
+normalize_right_no_trim = partial(normalize_seq, mode=NormalizationMode.RIGHTSHUFFLE, trim=False)
+normalize_expand_no_trim = partial(normalize_seq, mode=NormalizationMode.EXPAND, trim=False)
 
 
 @pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
@@ -35,6 +35,18 @@ def test_no_trim_no_shuffle():
     )
     assert ((22, 25), ("AGC", "AGCT")) == normalize_no_trim_no_shuffle(
         interval=(22, 25), alleles=(None, "AGCT")
+    )
+
+
+def test_shuffle_no_trim():
+    assert ((19, 22), ("AGC", "AGC")) == normalize_left_no_trim(
+        interval=(22, 25), alleles=(None, "AGC")
+    )
+    assert ((26, 29), ("GCA", "GCA")) == normalize_right_no_trim(
+        interval=(22, 25), alleles=(None, "AGC")
+    )
+    assert ((19, 29), ("AGCAGCAGCA", "AGCAGCAGCA")) == normalize_expand_no_trim(
+        interval=(22, 25), alleles=(None, "AGC")
     )
 
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -19,6 +19,15 @@ normalize_vcf = partial(normalize_seq, mode=NormalizationMode.VCF)
 # normalize_expand_no_trim = partial(normalize_seq, mode=None, trim=True)
 
 
+@pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
+def test_trim_matching_alleles_error(normalize_trim):
+    """Should raise error when trimming allele that matches reference allele."""
+    with pytest.raises(ValueError) as exc_info:
+        # (22, 25) on sequence is AGC
+        normalize_trim(interval=(22, 25), alleles=(None, "AGC"))
+    assert str(exc_info.value) == "Must have at least two distinct alleles to trim"
+
+
 def test_no_trim_no_shuffle():
     assert ((22, 25), ("AGC", "AGC")) == normalize_no_trim_no_shuffle(
         interval=(22, 25), alleles=(None, "AGC")

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -21,53 +21,53 @@ normalize_vcf_no_trim = partial(normalize_seq, mode=NormalizationMode.VCF, trim=
 
 
 @pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
-def test_trim(normalize_trim):
+def test_trim(normalize_fn):
     """Should trim common prefix and suffix when trim=True."""
-    assert ((25, 25), ("", "AC")) == normalize_trim(
+    assert ((25, 25), ("", "AC")) == normalize_fn(
         interval=(22, 25), alleles=(None, "AGCAC")
     )
-    assert ((24, 25), ("C", "", "CAC")) == normalize_trim(
+    assert ((24, 25), ("C", "", "CAC")) == normalize_fn(
         interval=(22, 25), alleles=(None, "AG", "AGCAC")
     )
-    assert ((23, 24), ("G", "", "GCA")) == normalize_trim(
+    assert ((23, 24), ("G", "", "GCA")) == normalize_fn(
         interval=(22, 25), alleles=(None, "AC", "AGCAC")
     )
-    assert ((22, 24), ("AG", "G", "AGCA")) == normalize_trim(
+    assert ((22, 24), ("AG", "G", "AGCA")) == normalize_fn(
         interval=(22, 25), alleles=(None, "GC", "AGCAC")
     )
 
 
 @pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
-def test_anchor(normalize_trim):
-    assert ((23, 25), ("GC", "")) == normalize_trim(
+def test_anchor(normalize_fn):
+    assert ((23, 25), ("GC", "")) == normalize_fn(
         interval=(22, 25), alleles=(None, "A"), anchor_length=0
     )
-    assert ((22, 26), ("AGCA", "AA")) == normalize_trim(
+    assert ((22, 26), ("AGCA", "AA")) == normalize_fn(
         interval=(22, 25), alleles=(None, "A"), anchor_length=1
     )
-    assert ((21, 27), ("CAGCAG", "CAAG")) == normalize_trim(
+    assert ((21, 27), ("CAGCAG", "CAAG")) == normalize_fn(
         interval=(22, 25), alleles=(None, "A"), anchor_length=2
     )
 
     # off the left
-    assert ((1, 1), ("", "C")) == normalize_trim(
+    assert ((1, 1), ("", "C")) == normalize_fn(
         interval=(1, 1), alleles=(None, "C"), anchor_length=0
     )
-    assert ((0, 2), ("CC", "CCC")) == normalize_trim(
+    assert ((0, 2), ("CC", "CCC")) == normalize_fn(
         interval=(1, 1), alleles=(None, "C"), anchor_length=1
     )
-    assert ((0, 3), ("CCC", "CCCC")) == normalize_trim(
+    assert ((0, 3), ("CCC", "CCCC")) == normalize_fn(
         interval=(1, 1), alleles=(None, "C"), anchor_length=2
     )
 
     # off the right
-    assert ((28, 28), ("", "C")) == normalize_trim(
+    assert ((28, 28), ("", "C")) == normalize_fn(
         interval=(28, 28), alleles=(None, "C"), anchor_length=0
     )
-    assert ((27, 29), ("CA", "CCA")) == normalize_trim(
+    assert ((27, 29), ("CA", "CCA")) == normalize_fn(
         interval=(28, 28), alleles=(None, "C"), anchor_length=1
     )
-    assert ((26, 29), ("GCA", "GCCA")) == normalize_trim(
+    assert ((26, 29), ("GCA", "GCCA")) == normalize_fn(
         interval=(28, 28), alleles=(None, "C"), anchor_length=2
     )
 
@@ -140,10 +140,10 @@ def test_input_alleles_not_modified():
 
 
 @pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
-def test_error_distinct(normalize_trim):
+def test_error_distinct(normalize_fn):
     """Must have at least two distinct allele sequences (incl. ref) to normalize"""
     with pytest.raises(ValueError):
-        normalize_trim(interval=(22, 25), alleles=(None, "AGC"))
+        normalize_fn(interval=(22, 25), alleles=(None, "AGC"))
 
 
 def test_error_ref_allele():

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -20,29 +20,6 @@ normalize_expand_no_trim = partial(normalize_seq, mode=NormalizationMode.EXPAND,
 normalize_vcf_no_trim = partial(normalize_seq, mode=NormalizationMode.VCF, trim=False)
 
 
-def test_no_trim_no_shuffle():
-    """Should not trim or shuffle when mode=None, trim=False."""
-    assert ((22, 25), ("AGC", "AGC")) == normalize_no_trim_no_shuffle(
-        interval=(22, 25), alleles=(None, "AGC")
-    )
-    assert ((22, 25), ("AGC", "AGCT")) == normalize_no_trim_no_shuffle(
-        interval=(22, 25), alleles=(None, "AGCT")
-    )
-
-
-def test_shuffle_no_trim():
-    """Should shuffle but not trim when mode!=None and trim=False."""
-    assert ((19, 22), ("AGC", "AGC")) == normalize_left_no_trim(
-        interval=(22, 25), alleles=(None, "AGC")
-    )
-    assert ((26, 29), ("GCA", "GCA")) == normalize_right_no_trim(
-        interval=(22, 25), alleles=(None, "AGC")
-    )
-    assert ((19, 29), ("AGCAGCAGCA", "AGCAGCAGCA")) == normalize_expand_no_trim(
-        interval=(22, 25), alleles=(None, "AGC")
-    )
-
-
 @pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
 def test_trim(normalize_trim):
     """Should trim common prefix and suffix when trim=True."""
@@ -118,6 +95,29 @@ def test_bounds():
     """ensure that bounds are honored"""
     assert ((20, 24), ("GCAG", "GCAGCAG")) == normalize_expand(
         interval=(22, 22), alleles=(None, "AGC"), bounds=(20, 24)
+    )
+
+
+def test_no_trim_no_shuffle():
+    """Should not trim or shuffle when mode=None, trim=False."""
+    assert ((22, 25), ("AGC", "AGC")) == normalize_no_trim_no_shuffle(
+        interval=(22, 25), alleles=(None, "AGC")
+    )
+    assert ((22, 25), ("AGC", "AGCT")) == normalize_no_trim_no_shuffle(
+        interval=(22, 25), alleles=(None, "AGCT")
+    )
+
+
+def test_shuffle_no_trim():
+    """Should shuffle but not trim when mode!=None and trim=False."""
+    assert ((19, 22), ("AGC", "AGC")) == normalize_left_no_trim(
+        interval=(22, 25), alleles=(None, "AGC")
+    )
+    assert ((26, 29), ("GCA", "GCA")) == normalize_right_no_trim(
+        interval=(22, 25), alleles=(None, "AGC")
+    )
+    assert ((19, 29), ("AGCAGCAGCA", "AGCAGCAGCA")) == normalize_expand_no_trim(
+        interval=(22, 25), alleles=(None, "AGC")
     )
 
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -19,15 +19,6 @@ normalize_right_no_trim = partial(normalize_seq, mode=NormalizationMode.RIGHTSHU
 normalize_expand_no_trim = partial(normalize_seq, mode=NormalizationMode.EXPAND, trim=False)
 
 
-@pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
-def test_trim_matching_alleles_error(normalize_trim):
-    """Should raise error when trimming allele that matches reference allele."""
-    with pytest.raises(ValueError) as exc_info:
-        # (22, 25) on sequence is AGC
-        normalize_trim(interval=(22, 25), alleles=(None, "AGC"))
-    assert str(exc_info.value) == "Must have at least two distinct alleles to trim"
-
-
 def test_no_trim_no_shuffle():
     """Should not trim or shuffle when mode=None, trim=False."""
     assert ((22, 25), ("AGC", "AGC")) == normalize_no_trim_no_shuffle(
@@ -145,7 +136,8 @@ def test_input_alleles_not_modified():
     assert (None, "AGCAC") == alleles
 
 
-def test_error_distinct():
+@pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
+def test_error_distinct(normalize_trim):
     """Must have at least two distinct allele sequences (incl. ref) to normalize"""
     with pytest.raises(ValueError):
         normalize_trim(interval=(22, 25), alleles=(None, "AGC"))

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -8,13 +8,15 @@ sequence = "CCCCCCCCACACACACACTAGCAGCAGCA"
 
 normalize_seq = partial(normalize, sequence=sequence)
 normalize_trim = partial(normalize_seq, mode=NormalizationMode.TRIMONLY)
+normalize_trim_no_shuffle = partial(normalize_seq, mode=None, trim=True)
 normalize_left = partial(normalize_seq, mode=NormalizationMode.LEFTSHUFFLE)
 normalize_right = partial(normalize_seq, mode=NormalizationMode.RIGHTSHUFFLE)
 normalize_expand = partial(normalize_seq, mode=NormalizationMode.EXPAND)
 normalize_vcf = partial(normalize_seq, mode=NormalizationMode.VCF)
 
 
-def test_trim():
+@pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
+def test_trim(normalize_trim):
     assert ((25, 25), ("", "AC")) == normalize_trim(
         interval=(22, 25), alleles=(None, "AGCAC")
     )

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -17,6 +17,7 @@ normalize_vcf = partial(normalize_seq, mode=NormalizationMode.VCF)
 normalize_left_no_trim = partial(normalize_seq, mode=NormalizationMode.LEFTSHUFFLE, trim=False)
 normalize_right_no_trim = partial(normalize_seq, mode=NormalizationMode.RIGHTSHUFFLE, trim=False)
 normalize_expand_no_trim = partial(normalize_seq, mode=NormalizationMode.EXPAND, trim=False)
+normalize_vcf_no_trim = partial(normalize_seq, mode=NormalizationMode.VCF, trim=False)
 
 
 def test_no_trim_no_shuffle():
@@ -148,3 +149,10 @@ def test_error_ref_allele():
     "First allele is ref allele and must be None"
     with pytest.raises(ValueError):
         normalize_trim(interval=(22, 25), alleles=("foo", "AGC"))
+
+
+def test_error_vcf_mode_no_trim():
+    """Should raise error when mode=VCF, trim=False."""
+    with pytest.raises(ValueError) as exc_info:
+        normalize_vcf_no_trim(interval=(22, 25), alleles=(None, "AGC"))
+    assert str(exc_info.value) == "May not disable trimming with VCF normalization mode"

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -30,6 +30,7 @@ def test_no_trim_no_shuffle():
 
 
 def test_shuffle_no_trim():
+    """Should shuffle but not trim when mode!=None and trim=False."""
     assert ((19, 22), ("AGC", "AGC")) == normalize_left_no_trim(
         interval=(22, 25), alleles=(None, "AGC")
     )

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -60,7 +60,8 @@ def test_trim(normalize_trim):
     )
 
 
-def test_anchor():
+@pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
+def test_anchor(normalize_trim):
     assert ((23, 25), ("GC", "")) == normalize_trim(
         interval=(22, 25), alleles=(None, "A"), anchor_length=0
     )

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -9,10 +9,23 @@ sequence = "CCCCCCCCACACACACACTAGCAGCAGCA"
 normalize_seq = partial(normalize, sequence=sequence)
 normalize_trim = partial(normalize_seq, mode=NormalizationMode.TRIMONLY)
 normalize_trim_no_shuffle = partial(normalize_seq, mode=None, trim=True)
+normalize_no_trim_no_shuffle = partial(normalize_seq, mode=None, trim=False)
 normalize_left = partial(normalize_seq, mode=NormalizationMode.LEFTSHUFFLE)
 normalize_right = partial(normalize_seq, mode=NormalizationMode.RIGHTSHUFFLE)
 normalize_expand = partial(normalize_seq, mode=NormalizationMode.EXPAND)
 normalize_vcf = partial(normalize_seq, mode=NormalizationMode.VCF)
+# normalize_left_no_trim = partial(normalize_seq, mode=None, trim=True)
+# normalize_right_no_trim = partial(normalize_seq, mode=None, trim=True)
+# normalize_expand_no_trim = partial(normalize_seq, mode=None, trim=True)
+
+
+def test_no_trim_no_shuffle():
+    assert ((22, 25), ("AGC", "AGC")) == normalize_no_trim_no_shuffle(
+        interval=(22, 25), alleles=(None, "AGC")
+    )
+    assert ((22, 25), ("AGC", "AGCT")) == normalize_no_trim_no_shuffle(
+        interval=(22, 25), alleles=(None, "AGCT")
+    )
 
 
 @pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -29,6 +29,7 @@ def test_trim_matching_alleles_error(normalize_trim):
 
 
 def test_no_trim_no_shuffle():
+    """Should not trim or shuffle when mode=None, trim=False."""
     assert ((22, 25), ("AGC", "AGC")) == normalize_no_trim_no_shuffle(
         interval=(22, 25), alleles=(None, "AGC")
     )
@@ -39,6 +40,7 @@ def test_no_trim_no_shuffle():
 
 @pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
 def test_trim(normalize_trim):
+    """Should trim common prefix and suffix when trim=True."""
     assert ((25, 25), ("", "AC")) == normalize_trim(
         interval=(22, 25), alleles=(None, "AGCAC")
     )

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -20,7 +20,7 @@ normalize_expand_no_trim = partial(normalize_seq, mode=NormalizationMode.EXPAND,
 normalize_vcf_no_trim = partial(normalize_seq, mode=NormalizationMode.VCF, trim=False)
 
 
-@pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
+@pytest.mark.parametrize('normalize_fn', [normalize_trim, normalize_trim_no_shuffle])
 def test_trim(normalize_fn):
     """Should trim common prefix and suffix when trim=True."""
     assert ((25, 25), ("", "AC")) == normalize_fn(
@@ -37,7 +37,7 @@ def test_trim(normalize_fn):
     )
 
 
-@pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
+@pytest.mark.parametrize('normalize_fn', [normalize_trim, normalize_trim_no_shuffle])
 def test_anchor(normalize_fn):
     assert ((23, 25), ("GC", "")) == normalize_fn(
         interval=(22, 25), alleles=(None, "A"), anchor_length=0
@@ -139,7 +139,7 @@ def test_input_alleles_not_modified():
     assert (None, "AGCAC") == alleles
 
 
-@pytest.mark.parametrize('normalize_trim', [normalize_trim, normalize_trim_no_shuffle])
+@pytest.mark.parametrize('normalize_fn', [normalize_trim, normalize_trim_no_shuffle])
 def test_error_distinct(normalize_fn):
     """Must have at least two distinct allele sequences (incl. ref) to normalize"""
     with pytest.raises(ValueError):


### PR DESCRIPTION
`normalize()` performs three operations: trimming, shuffling, anchoring. 

It does not allow shuffling without trimming.

This pull request:
- adds a `trim` argument to `normalize()` which determines whether the trimming operation runs
- allows the `mode` argument to be `None`; the docstring already indicates that it is optional, but setting `mode=None` hits an error [here](https://github.com/biocommons/bioutils/blob/0.5.6/src/bioutils/normalize.py#L85)
- deprecates `NormalizationMode.TRIMONLY`; the same operation can be achieved using `mode=None` with `trim=True`

Separate arguments `trim` and `mode` allow independent control of the trimming and shuffling operations. 