### PR TITLE
chore: remove whitespace

### DIFF
--- a/src/bioutils/accessions.py
+++ b/src/bioutils/accessions.py
@@ -20,7 +20,7 @@ Some sample serializations of Identifiers:
 
 ``xml: <Identifier namespace="RefSeq" accession="NM_000551.3"/>``
 
-``string: "RefSeq:NM_000551.3"``  
+``string: "RefSeq:NM_000551.3"``
 
 The string form may be used as a CURIE, in which case the document in
 which the CURIE is used must contain a map of ``{namespace : uri}``.

--- a/src/bioutils/assemblies.py
+++ b/src/bioutils/assemblies.py
@@ -1,4 +1,4 @@
-"""Creates dictionaries of genome assembly data as provided by  
+"""Creates dictionaries of genome assembly data as provided by
 
 ftp://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/All/*.assembly.txt
 


### PR DESCRIPTION
Cribbing description from https://github.com/biocommons/hgvs/pull/737

> A lot of modern editors will auto-trim trailing whitespace upon save. Unfortunately, if there's a pesky space or two hanging around on some old file, then a new commit might create an unrelated edit on that line simply by making a functional change elsewhere in the file. This PR gets this out of the way for every `.py` file.
