### PR TITLE
refactor: use importlib instead of pkg_resources

### DIFF
--- a/src/bioutils/_data/__init__.py
+++ b/src/bioutils/_data/__init__.py
@@ -1,1 +1,0 @@
-"""Provide assembly and cytoband data resources."""

--- a/src/bioutils/_data/__init__.py
+++ b/src/bioutils/_data/__init__.py
@@ -1,0 +1,1 @@
+"""Provide assembly and cytoband data resources."""

--- a/src/bioutils/assemblies.py
+++ b/src/bioutils/assemblies.py
@@ -46,9 +46,7 @@ def get_assembly_names():
     """
     assemblies_path = resources.files(_data) / _assy_dir
 
-    return [
-        n.name.replace(".json.gz", "") for n in assemblies_path.iterdir() if n.name.endswith(".json.gz")
-    ]
+    return [n.name.replace(".json.gz", "") for n in assemblies_path.iterdir() if n.name.endswith(".json.gz")]
 
 
 def get_assembly(name):

--- a/src/bioutils/assemblies.py
+++ b/src/bioutils/assemblies.py
@@ -25,11 +25,11 @@ Definitions:
 
 import gzip
 import json
+from importlib import resources
 
-import pkg_resources
+from bioutils import _data
 
-_assy_dir = "_data/assemblies"
-_assy_path_fmt = _assy_dir + "/" + "{name}.json.gz"
+_assy_dir = "assemblies"
 
 
 def get_assembly_names():
@@ -44,9 +44,10 @@ def get_assembly_names():
         >>> 'GRCh37.p13' in assy_names
         True
     """
+    assemblies_path = resources.files(_data) / _assy_dir
 
     return [
-        n.replace(".json.gz", "") for n in pkg_resources.resource_listdir(__name__, _assy_dir) if n.endswith(".json.gz")
+        n.name.replace(".json.gz", "") for n in assemblies_path.iterdir() if n.name.endswith(".json.gz")
     ]
 
 
@@ -89,8 +90,10 @@ def get_assembly(name):
         'relationship': '=',
         'sequence_role': 'assembled-molecule'}
     """
+    fn = resources.files(_data) / _assy_dir / f"{name}.json.gz"
+    if not fn.exists():
+        raise FileNotFoundError
 
-    fn = pkg_resources.resource_filename(__name__, _assy_path_fmt.format(name=name))
     return json.load(gzip.open(fn, mode="rt", encoding="utf-8"))
 
 

--- a/src/bioutils/assemblies.py
+++ b/src/bioutils/assemblies.py
@@ -27,10 +27,6 @@ import gzip
 import json
 from importlib import resources
 
-from bioutils import _data
-
-_assy_dir = "assemblies"
-
 
 def get_assembly_names():
     """Retrieves available assemblies from the ``_data/assemblies`` directory.
@@ -44,7 +40,7 @@ def get_assembly_names():
         >>> 'GRCh37.p13' in assy_names
         True
     """
-    assemblies_path = resources.files(_data) / _assy_dir
+    assemblies_path = resources.files(__package__) / "_data" / "assemblies"
 
     return [n.name.replace(".json.gz", "") for n in assemblies_path.iterdir() if n.name.endswith(".json.gz")]
 
@@ -88,7 +84,7 @@ def get_assembly(name):
         'relationship': '=',
         'sequence_role': 'assembled-molecule'}
     """
-    fn = resources.files(_data) / _assy_dir / f"{name}.json.gz"
+    fn = resources.files(__package__) / "_data" / "assemblies" / f"{name}.json.gz"
     if not fn.exists():
         raise FileNotFoundError
 


### PR DESCRIPTION
Use `importlib.resources.files(__package__)`  to get to `_data`. I think, from reading (https://discuss.python.org/t/easy-and-recommended-way-to-get-path-of-datafile-within-package/20581/4) and (https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package/58941536) that this is the best way forward. 