### PR TITLE
chore: remove __future__ imports

### DIFF
--- a/sbin/assembly-to-json
+++ b/sbin/assembly-to-json
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """convert assembly text file to json
 
 eg$ ./sbin/assembly-to-json -p bioutils/_data/assemblies -f pull/GCF_000001405.29.assembly.txt
@@ -27,7 +24,7 @@ class AssemblyParser(object):
 
     def __init__(self, body):
         self._body = body.replace("\r","")
-    
+
     @property
     def name(self):
         return re.search("^# Assembly name:\s+(\S+)", self._body, flags=re.MULTILINE).group(1).strip()
@@ -42,7 +39,7 @@ class AssemblyParser(object):
     @property
     def taxid(self):
         return re.search("^# Taxid:\s+(\S+)", self._body, flags=re.MULTILINE).group(1).strip()
-    
+
     @property
     def genbank_accession(self):
         try:
@@ -148,4 +145,4 @@ if __name__ == "__main__":
         except Exception as e:
             logger.error("oopsie on " + assy_id_or_name)
             logger.exception(e)
-            
+

--- a/src/bioutils/accessions.py
+++ b/src/bioutils/accessions.py
@@ -25,9 +25,6 @@ Some sample serializations of Identifiers:
 The string form may be used as a CURIE, in which case the document in
 which the CURIE is used must contain a map of ``{namespace : uri}``.
 """
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import re
 
 from .exceptions import BioutilsError

--- a/src/bioutils/coordinates.py
+++ b/src/bioutils/coordinates.py
@@ -32,8 +32,6 @@ For code clarity, this module provides functions that interconvert
 *intervals* specified in each of the coordinate systems.
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 PLUS_STRAND = 1
 MINUS_STRAND = -1
 

--- a/src/bioutils/seqfetcher.py
+++ b/src/bioutils/seqfetcher.py
@@ -2,9 +2,6 @@
 """Provides sequence fetching from NCBI and Ensembl.
 
 """
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import logging
 import os
 import random

--- a/src/bioutils/vmc_digest.py
+++ b/src/bioutils/vmc_digest.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import hashlib
 
 from .digest import Digest


### PR DESCRIPTION
Doing my daily biocommons cleanup. None of these are necessary anymore: https://docs.python.org/3/library/__future__.html

* as a side note, I'm always a little hesitant to edit stuff in `bin/` and `sbin/` for some reason -- I often wonder if we should be including these commands in the released package (i.e. as `entry-points`)