### PR TITLE
test: ignore existing NCBI_API_KEY env var

### DIFF
--- a/tests/test_seqfetcher.py
+++ b/tests/test_seqfetcher.py
@@ -11,6 +11,12 @@ from bioutils.seqfetcher import (
     fetch_seq,
 )
 
+@pytest.fixture(autouse=True)
+def clear_env():
+    if "NCBI_API_KEY" in os.environ:
+        del os.environ["NCBI_API_KEY"]
+
+
 
 @vcr.use_cassette
 def test_fetch_seq():

--- a/tests/test_seqfetcher.py
+++ b/tests/test_seqfetcher.py
@@ -13,6 +13,10 @@ from bioutils.seqfetcher import (
 
 @pytest.fixture(autouse=True)
 def clear_env():
+    """Some tests in this module assume that the default utils access configs are
+    active. If you execute tests in an environment with an existing `NCBI_API_KEY` env
+    var, those tests will fail unless we first remove that variable.
+    """
     if "NCBI_API_KEY" in os.environ:
         del os.environ["NCBI_API_KEY"]
 

--- a/tests/test_seqfetcher.py
+++ b/tests/test_seqfetcher.py
@@ -10,6 +10,7 @@ from bioutils.seqfetcher import (
     fetch_seq,
 )
 
+
 @pytest.fixture(autouse=True)
 def clear_env():
     """Some tests in this module assume that the default utils access configs are
@@ -18,7 +19,6 @@ def clear_env():
     """
     if "NCBI_API_KEY" in os.environ:
         del os.environ["NCBI_API_KEY"]
-
 
 
 @vcr.use_cassette


### PR DESCRIPTION
Noticed while checking a recent PR that `seqfetcher` tests weren't passing for me locally. The issue was that I had a preset NCBI_API_KEY env var, and part of the test assumed use of the default authentication configs. This PR adds an `autouse` fixture to that test module to blank out the `NCBI_API_KEY` env var before tests run.
